### PR TITLE
Add query options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ new Wordpress({
 
 #### apply query params per type
 
-to apply a set of query parameters to an array of `postTypes`, pass in a config object instead of a string:
+the wordpress api offers a [number](https://developer.wordpress.com/docs/api/1/get/sites/%24site/posts/) of
+optional query parameters you can use to modify your requests. to apply a set of params to a `postType`, pass in a config object instead of a string, eg:
 
 ```js
 const locals = {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const joi = require('joi')
 const W = require('when')
 const node = require('when/node')
 const rest = require('rest')
-const template = require('rest/interceptor/template')
+const params = require('rest/interceptor/params')
 const mime = require('rest/interceptor/mime')
 const errorCode = require('rest/interceptor/errorCode')
 const pathPrefix = require('rest/interceptor/pathPrefix')
@@ -83,16 +83,15 @@ module.exports = class Wordpress {
 }
 
 //  hit the wp api
-const fetch = (site, params) => {
+const fetch = (site, opts) => {
   let url = `https://public-api.wordpress.com/rest/v1/sites/${site}/posts`
 
   let client = rest.wrap(mime, {mime: 'application/json'})
   .wrap(errorCode)
   .wrap(pathPrefix, { prefix: url })
-  .wrap(template, { params: params })
+  .wrap(params, { params: opts })
 
   return client().then(r => r.entity)
-  // client({params: params}) and client({path: '/', params: params}) have the same result
 }
 
 //  default transform function applied to each post

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ const joi = require('joi')
 const W = require('when')
 const node = require('when/node')
 const rest = require('rest')
+const template = require('rest/interceptor/template')
 const mime = require('rest/interceptor/mime')
 const errorCode = require('rest/interceptor/errorCode')
 const pathPrefix = require('rest/interceptor/pathPrefix')
@@ -83,28 +84,15 @@ module.exports = class Wordpress {
 
 //  hit the wp api
 const fetch = (site, params) => {
-  let url = `https://public-api.wordpress.com/rest/v1/sites/${site}/posts${serialize(params)}`
+  let url = `https://public-api.wordpress.com/rest/v1/sites/${site}/posts`
 
   let client = rest.wrap(mime, {mime: 'application/json'})
   .wrap(errorCode)
-  .wrap(pathPrefix, {
-    prefix: url
-  })
+  .wrap(pathPrefix, { prefix: url })
+  .wrap(template, { params: params })
 
-  return client({
-    params: params  //  FIXME: why doesn't this work?
-  }).then(r => r.entity)
-}
-
-//  serialize an object into a query param string. temporary hack to get around rest.js params not sticking...
-const serialize = (params) => {
-  let whitelist = ['category', 'order', 'search', 'number']
-
-  return (!params) ? '' : '?' + Object.keys(params)
-  .filter(p => whitelist.includes(p))
-  .map(p => `${p}=${params[p]}&`)
-  .reduce((p, c) => p + c)
-  .slice(0, -1)
+  return client().then(r => r.entity)
+  // client({params: params}) and client({path: '/', params: params}) have the same result
 }
 
 //  default transform function applied to each post

--- a/test/index.js
+++ b/test/index.js
@@ -76,7 +76,7 @@ test.cb('fetches multiple postTypes', (t) => {
   })
 })
 
-test.cb('implements query search', (t) => {
+test.cb('implements query params', (t) => {
   const locals = {}
   const api = new Wordpress({
     name: process.env.NAME,
@@ -90,41 +90,6 @@ test.cb('implements query search', (t) => {
   api.run(compilerMock, undefined, () => {
     t.is(locals.wordpress.review.length, 1)
     t.is(locals.wordpress.review[0].slug, 'my-nice-review')
-    t.end()
-  })
-})
-
-test.cb('implements query order', (t) => {
-  const locals = {}
-  const api = new Wordpress({
-    name: process.env.NAME,
-    addDataTo: locals,
-    postTypes: [{
-      category: 'review',
-      order: 'ASC'
-    }]
-  })
-
-  api.run(compilerMock, undefined, () => {
-    t.is(locals.wordpress.review.length, 2)
-    t.is(locals.wordpress.review[1].slug, 'my-second-review')
-    t.end()
-  })
-})
-
-test.cb('implements query limit', (t) => {
-  const locals = {}
-  const api = new Wordpress({
-    name: process.env.NAME,
-    addDataTo: locals,
-    postTypes: [{
-      category: 'review',
-      number: '1'
-    }]
-  })
-
-  api.run(compilerMock, undefined, () => {
-    t.is(locals.wordpress.review.length, 1)
     t.end()
   })
 })


### PR DESCRIPTION
correct usage of rest.js = pass any query parameter straight thru to the wp-api 💯 